### PR TITLE
V2 rust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      
-      - name: Update Cargo.toml version
-        run: |
-          VERSION=$(grep '"version":' package.json | sed -E 's/.*"version": "([^"]+)".*/\1/')
-          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
-      
-      # Upload just the Cargo.toml file as an artifact
-      - name: Upload Cargo.toml
-        uses: actions/upload-artifact@v4
-        with:
-          name: cargo-toml
-          path: Cargo.toml
 
   build-and-upload:
     name: Build for ${{ matrix.os }} / ${{ matrix.target }}
@@ -61,13 +49,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      
-      # Download the updated Cargo.toml
-      - name: Download Cargo.toml
-        uses: actions/download-artifact@v4
-        with:
-          name: cargo-toml
-          path: .
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1

--- a/release.sh
+++ b/release.sh
@@ -1,27 +1,30 @@
 #!/bin/bash
 set -e
 
-# Run tests
-cargo test --verbose
+PACKAGE_VERSION=$(grep -oP '"version": "\K[^"]+' package.json)
 
 # Use changelogen to prepare release files without committing
 npx changelogen --release --no-commit --no-tag
 
 # Sync versions
-PACKAGE_VERSION=$(grep -oP '"version": "\K[^"]+' package.json)
 sed -i "s/^version = \".*\"/version = \"$PACKAGE_VERSION\"/" Cargo.toml
-cargo check --quiet
 
-# Stage all files
+# Run tests
+cargo test --verbose
+cargo check --quiet
+cargo fmt --all -- --check
+cargo clippy -- -D warnings
+
+# Stage all files 
 git add package.json CHANGELOG.md Cargo.toml Cargo.lock
 
-# Create commit and tag
-git commit -m "chore(release): v$PACKAGE_VERSION" package.json CHANGELOG.md Cargo.toml Cargo.lock
+# Tag and commit
 git tag "v$PACKAGE_VERSION"
+git commit -m "chore(release): v$PACKAGE_VERSION" package.json CHANGELOG.md Cargo.toml Cargo.lock
 
 # Push everything (this will trigger GitHub release creation in browser)
 git push --follow-tags
 
 # Publish to registries
-cargo publish
 npm publish
+cargo publish


### PR DESCRIPTION
# :crab:  Rust rewrite of port-claim (v2.0.0)

This PR rewrites the port-claim utility in Rust, replacing the TypeScript implementation with a native binary approach.

## What's changed
- Core functionality rewritten in Rust for better performance
- Added binary distribution via npm using index.mjs and [binary-install](https://github.com/EverlastingBugstopper/binary-install)
- Cross-platform binaries (Linux/macOS/Windows, x64/arm64/x86)
- New feature: support for checking multiple ports in a single command
- Updated documentation with installation methods and examples
- Added GitHub Actions for CI/CD and binary releases

The binary approach runs approximately 100x faster than the previous TypeScript implementation. First installation may take slightly longer due to downloading the OS-specific binary, but subsequent runs are significantly faster.

All tests pass on all target platforms. Ready to be released as v2.0.0 after merging.
